### PR TITLE
Add C++ tests for cross-platform error code checks.

### DIFF
--- a/.github/workflows/library-check.yaml
+++ b/.github/workflows/library-check.yaml
@@ -52,3 +52,28 @@ jobs:
   #
   # Add any custom jobs you need below this comment.
   # The area above this comment is reserved for future standard jobs.
+
+  # Use a C++ compiler to check vs the "real" error codes on each platform.
+  cpp-check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: windows-latest, shell: 'wsl-bash {0}' }
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: savi-lang/action-install@v1
+      - run: savi deps update --for c++-check-program
+      - run: sudo apt-get install mingw-w64 -y
+        if: runner.os == 'Windows'
+      - run: " \
+          savi run c++-check-program \
+            ${{ runner.os == 'Windows' && '--cross-compile=x86_64-unknown-windows-msvc' || '' }} \
+            | ${{ runner.os == 'Windows' && 'x86_64-w64-mingw32-gcc' || 'c++' }} -x c++ -o /dev/null - \
+          "

--- a/c++-check-program/Main.savi
+++ b/c++-check-program/Main.savi
@@ -1,0 +1,25 @@
+:: Print a C++ program that checks the mapping of error codes by names,
+:: comparing what we have implemented to what the C++ compiler resolves.
+::
+:: For this C++ program to compile, all of the `static_assert`s must pass,
+:: which means all of our error code mappings in Savi must be correct.
+::
+:: Therefore we can test our error code mappings py piping the printed C++ code
+:: into a C++ compiler, with a command like this:
+:: ```
+:: savi run c++-check-program | c++ -x c++ -o /dev/null -
+:: ```
+:actor Main
+  :new (env)
+    env.out.print("#include <errno.h>")
+
+    OSError.each_supported_in_platform -> (error |
+      next if error == 0
+
+      env.out.print("static_assert( \
+        \(error.name) == \(error.u32), \
+        \"\(error.name) == \(error.u32)\" \
+      );")
+    )
+
+    env.out.print("int main() { return 0; }")

--- a/manifest.savi
+++ b/manifest.savi
@@ -20,3 +20,7 @@
   :transitive dependency Timer v0
     :from "github:savi-lang/Timer"
     :depends on Time
+
+:manifest bin "c++-check-program"
+  :copies OSError
+  :sources "c++-check-program/*.savi"

--- a/spec/OSError.Spec.savi
+++ b/spec/OSError.Spec.savi
@@ -16,7 +16,7 @@
     | Platform.is_linux   | assert: count == 123
     | Platform.is_bsd     | assert: count == 76
     | Platform.is_macos   | assert: count == 76
-    | Platform.is_windows | assert: count == 41
+    | Platform.is_windows | assert: count == 40
     |                       assert: count == 0 // (unsupported platform)
     )
 

--- a/src/OSError.savi
+++ b/src/OSError.savi
@@ -20,11 +20,29 @@
   :fun non enoexec @'val: 8
   :fun non ebadf @'val: 9
   :fun non echild @'val: 10
-  :fun non eagain @'val: 11
+
+  :fun non eagain @'val
+    case (
+    | Platform.is_linux   | 11
+    | Platform.is_bsd     | 35
+    | Platform.is_macos   | 35
+    | Platform.is_windows | 11
+    | -1
+    )
+
   :fun non enomem @'val: 12
   :fun non eacces @'val: 13
   :fun non efault @'val: 14
-  :fun non enotblk @'val: 15
+
+  :fun non enotblk @'val
+    case (
+    | Platform.is_linux   | 15
+    | Platform.is_bsd     | 15
+    | Platform.is_macos   | 15
+    | Platform.is_windows | -1 // (doesn't have this error code)
+    | -1
+    )
+
   :fun non ebusy @'val: 16
   :fun non eexist @'val: 17
   :fun non exdev @'val: 18
@@ -35,7 +53,16 @@
   :fun non enfile @'val: 23
   :fun non emfile @'val: 24
   :fun non enotty @'val: 25
-  :fun non etxtbsy @'val: 26
+
+  :fun non etxtbsy @'val
+    case (
+    | Platform.is_linux   | 26
+    | Platform.is_bsd     | 26
+    | Platform.is_macos   | 26
+    | Platform.is_windows | 139
+    | -1
+    )
+
   :fun non efbig @'val: 27
   :fun non enospc @'val: 28
   :fun non espipe @'val: 29
@@ -448,7 +475,7 @@
     case (
     | Platform.is_linux   | 95
     | Platform.is_bsd     | 45
-    | Platform.is_macos   | 45
+    | Platform.is_macos   | 102
     | Platform.is_windows | -1 // (doesn't have this error code)
     | -1
     )


### PR DESCRIPTION
This adds a new Savi program to the repo, which can print a C++ program that checks the mapping of error codes by names, comparing what we have implemented to what the C++ compiler resolves.

This will let us quickly find out if any of the error codes we have defined are at variance with what a C/C++ program would see.

Note that this PR actually includes a few platform-specific error code fixes, for issues noticed by this new check, so it's already paying off.