### PR TITLE
Add OSError.from_u32! function.

### DIFF
--- a/spec/OSError.Spec.savi
+++ b/spec/OSError.Spec.savi
@@ -39,3 +39,12 @@
     assert: OSError.eperm.description == "Operation not permitted"
     assert: OSError[-1].description == "Unsupported error code for this platform"
     assert: OSError[999].description == "Unknown error code 999"
+
+  :it "converts a U32 to an error code if it's a valid one"
+    assert: OSError.from_u32!(0) == OSError.success
+    assert: OSError.from_u32!(1) == OSError.eperm
+    assert error: OSError.from_u32!(999)
+
+    OSError.each_supported_in_platform -> (error |
+      assert: OSError.from_u32!(error.u32) == error
+    )

--- a/src/OSError.savi
+++ b/src/OSError.savi
@@ -5,6 +5,12 @@
   :fun into_string(out String'ref): @name.into_string(out)
   :fun into_string_space: @name.into_string_space
 
+  :fun non from_u32!(value U32) OSError
+    @each_supported_in_platform -> (error |
+      return error if error.u32 == value
+    )
+    error!
+
   // Note: cross-platform numeric codes have been sourced from:
   // <http://www.ioplex.com/~miallen/errcmp.html>
 


### PR DESCRIPTION
This allows converting a U32 value to an OSError value, as long as the U32 value is one of the supported
error codes on the current platform.